### PR TITLE
Add periodic motor plate pulse automation and script

### DIFF
--- a/automations.yaml
+++ b/automations.yaml
@@ -1313,3 +1313,18 @@
           entity_id: input_boolean.chime_enable
         action: input_boolean.turn_on
   mode: single
+- id: '1757788888888'
+  alias: Motor ploče – periodični impuls
+  triggers:
+  - minutes: '14,29,44,59'
+    seconds: '0'
+    trigger: time_pattern
+  conditions:
+  - condition: time
+    after: '04:59:00'
+    before: '20:45:00'
+  actions:
+  - action: script.turn_on
+    target:
+      entity_id: script.motor_ploce_impuls_poz_neg
+  mode: single

--- a/scripts.yaml
+++ b/scripts.yaml
@@ -335,3 +335,23 @@ otkucavanje_pola_sata_zenski_1:
       entity_id: switch.cekic_zensko
     action: switch.turn_off
   description: ''
+motor_ploce_impuls_poz_neg:
+  alias: Motor ploče – impuls POZ + NEG
+  mode: single
+  sequence:
+  - action: switch.turn_on
+    target:
+      entity_id: switch.motor_poz
+  - delay: 00:00:01
+  - action: switch.turn_off
+    target:
+      entity_id: switch.motor_poz
+  - delay: 00:00:01
+  - action: switch.turn_on
+    target:
+      entity_id: switch.motor_neg
+  - delay: 00:00:01
+  - action: switch.turn_off
+    target:
+      entity_id: switch.motor_neg
+  description: ''


### PR DESCRIPTION
## Summary
- add script to trigger one positive and one negative motor pulse
- schedule pulses at minutes 14, 29, 44, and 59 between 04:59 and 20:44

## Testing
- `yamllint automations.yaml scripts.yaml` *(fails: multiple indentation and line-length errors in existing files)*

------
https://chatgpt.com/codex/tasks/task_e_68a0a10472208328ab80b7e027e9692f