### PR TITLE
Extend motor impulse durations to six seconds

### DIFF
--- a/scripts.yaml
+++ b/scripts.yaml
@@ -336,22 +336,21 @@ otkucavanje_pola_sata_zenski_1:
     action: switch.turn_off
   description: ''
 motor_ploce_impuls_poz_neg:
-  alias: Motor ploče – impuls POZ + NEG
+  alias: Motor ploče – impuls POZ + NEG (6 s)
   mode: single
   sequence:
   - action: switch.turn_on
     target:
       entity_id: switch.motor_poz
-  - delay: 00:00:01
+  - delay: 00:00:06
   - action: switch.turn_off
     target:
       entity_id: switch.motor_poz
-  - delay: 00:00:01
   - action: switch.turn_on
     target:
       entity_id: switch.motor_neg
-  - delay: 00:00:01
+  - delay: 00:00:06
   - action: switch.turn_off
     target:
       entity_id: switch.motor_neg
-  description: ''
+  description: Runs motor positive then negative for 6 seconds each.


### PR DESCRIPTION
## Summary
- Run motor positive and negative directions for 6 seconds each

## Testing
- `yamllint automations.yaml scripts.yaml` (fails: indentation and line length errors)


------
https://chatgpt.com/codex/tasks/task_e_68a0a2a3a3d88328bab7330668b5ad1c